### PR TITLE
conduit 0.4 compatibility

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -1,5 +1,5 @@
 Name:                   simple-sendfile
-Version:                0.2.1
+Version:                0.2.2
 Author:                 Kazu Yamamoto <kazu@iij.ad.jp>
 Maintainer:             Kazu Yamamoto <kazu@iij.ad.jp>
 License:                BSD3
@@ -37,7 +37,9 @@ Library
         Build-Depends: unix
       else
         Other-Modules: Network.Sendfile.Fallback
-        Build-Depends: bytestring, conduit, transformers
+        Build-Depends: bytestring      >= 0.9   && < 0.10
+                     , conduit         >= 0.4   && < 0.5
+                     , transformers    >= 0.2.2 && < 0.4
 
 Source-Repository head
   Type:                 git


### PR DESCRIPTION
@snoyberg, @gregweber, @kazu-yamamoto

The current version is written for conduit 0.2, but does not have any version constraints, so it fails to build on Windows with Yesod 1.0 release candidate. Can you release this update quickly? (I hope it's correct)
