### PR TITLE
conduit 0.5 support

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -41,7 +41,7 @@ Library
       else
         Other-Modules:  Network.Sendfile.Fallback
         Build-Depends:  bytestring      >= 0.9   && < 0.10
-                      , conduit         >= 0.4.1 && < 0.5
+                      , conduit         >= 0.4.1 && < 0.6
                       , transformers    >= 0.2.2 && < 0.4
 
 Test-Suite spec


### PR DESCRIPTION
Conditionally adds 0.5 support. Only affects the fallback option (so likely only Windows).
