### PR TITLE
Insert missing getErrno call

### DIFF
--- a/Network/Sendfile/Linux.hsc
+++ b/Network/Sendfile/Linux.hsc
@@ -104,6 +104,7 @@ sendloop dst src offp len hook = do
         hook
         -- Parallel IO manager use edge-trigger mode.
         -- So, calling threadWaitWrite only when errnor is eAGAIN.
+        errno <- getErrno
         when (errno == eAGAIN) $ threadWaitWrite dst
         sendloop dst src offp left hook
 


### PR DESCRIPTION
This fixes a build problem on Linux:

$ cabal build
Building simple-sendfile-0.2.9...
Preprocessing library simple-sendfile-0.2.9...
[1 of 3] Compiling Network.Sendfile.Types ( Network/Sendfile/Types.hs, dist_cqrs/build/Network/Sendfile/Types.o )
[2 of 3] Compiling Network.Sendfile.Linux ( dist_cqrs/build/Network/Sendfile/Linux.hs, dist_cqrs/build/Network/Sendfile/Linux.o )

Network/Sendfile/Linux.hsc:107:15: Not in scope: `errno'
