### PR TITLE
Bumped transformers version number

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -46,7 +46,7 @@ Library
         Other-Modules:  Network.Sendfile.Fallback
         Build-Depends:  conduit         >= 1.0 && < 1.2
                       , conduit-extra   >= 1.0 && < 1.2
-                      , transformers    >= 0.2.2 && < 0.4
+                      , transformers    >= 0.2.2 && < 0.5
 
 Test-Suite spec
   Type:                 exitcode-stdio-1.0


### PR DESCRIPTION
This change simply bumps the upper version bound of `transformers` to 0.5 to allow for the most recent version to be used. No changes introduced in version 0.4.\* of `transformers` affect `simple-sendfile`.
