### PR TITLE
use autoconf for correct bit-ness of off_t/sendfile()

### DIFF
--- a/Network/Sendfile/BSD.hsc
+++ b/Network/Sendfile/BSD.hsc
@@ -24,6 +24,7 @@ import Network.Socket.ByteString
 import System.Posix.IO
 import System.Posix.Types
 
+#include "HsConfig.h"
 #include <sys/types.h>
 
 entire :: COff

--- a/Network/Sendfile/IOVec.hsc
+++ b/Network/Sendfile/IOVec.hsc
@@ -18,6 +18,7 @@ import Foreign.Marshal.Array (allocaArray)
 import Foreign.Ptr (Ptr, nullPtr, plusPtr)
 import Foreign.Storable (Storable(..))
 
+#include "HsConfig.h"
 #include <sys/uio.h>
 #include <sys/socket.h>
 

--- a/Network/Sendfile/Linux.hsc
+++ b/Network/Sendfile/Linux.hsc
@@ -26,6 +26,7 @@ import System.Posix.Files
 import System.Posix.IO
 import System.Posix.Types
 
+#include "HsConfig.h"
 #include <sys/sendfile.h>
 #include <sys/socket.h>
 

--- a/README
+++ b/README
@@ -1,0 +1,4 @@
+To build this package using Cabal directly from darcs, you must run
+"autoreconf" before the usual Cabal build steps (configure/build/install).
+autoreconf is included in the GNU autoconf tools.  There is no need to run
+the "configure" script: the "setup configure" step will do this for you.

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,15 @@
+AC_INIT([Haskell simple sendfile interface], [0.2.x], [kazu@iij.ad.jp], [simple-sendfile])
+
+dnl ** Modeled after Haskell's "unix" package **
+
+AC_CONFIG_SRCDIR([Network/Sendfile.hs])
+
+AC_CONFIG_HEADERS([Network/Sendfile/HsConfig.h])
+
+AC_C_CONST
+
+dnl ** Enable large file support.  NB. do this before testing the type of
+dnl    off_t, because it will affect the result of that test.
+AC_SYS_LARGEFILE
+
+AC_OUTPUT

--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -10,13 +10,23 @@ Description:            Cross platform library for the sendfile system call.
                         are the bottleneck of web servers.
 Category:               Network
 Cabal-Version:          >= 1.10
-Build-Type:             Simple
+Build-Type:             Configure
+
+extra-source-files:
+                config.guess config.sub install-sh
+                configure.ac configure
+                Network/Sendfile/HsConfig.h.in
+extra-tmp-files:
+                config.log config.status autom4te.cache
+                Network/Sendfile/HsConfig.h
 
 Flag allow-bsd
   Description:          Allow use of BSD sendfile (disable on GNU/kFreeBSD)
   Default:              True
 
 Library
+  include-dirs: Network/Sendfile
+  includes:     HsConfig.h
   Default-Language:     Haskell2010
   GHC-Options:          -Wall
   Exposed-Modules:      Network.Sendfile


### PR DESCRIPTION
I have no 32bit systems to test it, so it's only checked on 64bit Linux (where none of the LARGEFILE-matic is necessary anyway. So please test before merging into mainline.