### PR TITLE
Allow to use non-sockets on posix systems

### DIFF
--- a/System/Posix/IO/Sendfile.hs
+++ b/System/Posix/IO/Sendfile.hs
@@ -1,0 +1,42 @@
+module System.Posix.IO.Sendfile (
+    sendfile
+  , I.sendfileFd
+  , FileRange(..)
+  ) where
+
+import Control.Exception
+import System.Posix.IO
+import qualified System.Posix.IO.Sendfile.Internal as I
+import System.Posix.IO.Sendfile.Types
+import System.Posix.Types
+
+
+
+----------------------------------------------------------------
+
+-- |
+-- Simple binding for sendfile() of Linux.
+-- Used system calls:
+--
+--  - EntireFile -- open(), stat(), sendfile(), and close()
+--
+--  - PartOfFile -- open(), sendfile(), and close()
+--
+-- If the size of the file is unknown when sending the entire file,
+-- specifying PartOfFile is much faster.
+--
+-- This is meant to copy files. If you want to operate on sockets,
+-- use `Network.Sendfile` instead.
+--
+-- This function can fail with EINVAL or ENOSYS on older linux
+-- kernels, so you may want to catch these errors
+-- and fall back to a different copy method.
+sendfile :: Fd -> FilePath -> FileRange -> IO ()
+sendfile out_fd path range = bracket setup teardown $ \fd ->
+    I.sendfileFd out_fd fd range
+  where
+    setup = openFd path ReadOnly Nothing defaultFileFlags
+    teardown = closeFd
+
+----------------------------------------------------------------
+

--- a/System/Posix/IO/Sendfile/ByteString.hs
+++ b/System/Posix/IO/Sendfile/ByteString.hs
@@ -1,0 +1,43 @@
+module System.Posix.IO.Sendfile.ByteString (
+    sendfile
+  , I.sendfileFd
+  , FileRange(..)
+  ) where
+
+import Control.Exception
+import Data.ByteString (ByteString)
+import System.Posix.IO.ByteString
+import qualified System.Posix.IO.Sendfile.Internal as I
+import System.Posix.IO.Sendfile.Types
+import System.Posix.Types
+
+
+----------------------------------------------------------------
+
+-- |
+-- Simple binding for sendfile() of Linux.
+-- Used system calls:
+--
+--  - EntireFile -- open(), stat(), sendfile(), and close()
+--
+--  - PartOfFile -- open(), sendfile(), and close()
+--
+-- If the size of the file is unknown when sending the entire file,
+-- specifying PartOfFile is much faster.
+--
+-- This is meant to copy files. If you want to operate on sockets,
+-- use `Network.Sendfile` instead.
+--
+-- This function can fail with EINVAL or ENOSYS on older linux
+-- kernels, so you may want to catch these errors
+-- and fall back to a different copy method.
+sendfile :: Fd -> ByteString -> FileRange -> IO ()
+sendfile out_fd path range = bracket setup teardown $ \fd ->
+    I.sendfileFd out_fd fd range
+  where
+    setup = openFd path ReadOnly Nothing defaultFileFlags
+    teardown = closeFd
+
+
+----------------------------------------------------------------
+

--- a/System/Posix/IO/Sendfile/Internal.hsc
+++ b/System/Posix/IO/Sendfile/Internal.hsc
@@ -1,0 +1,84 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module System.Posix.IO.Sendfile.Internal where
+
+import Control.Applicative
+import Control.Monad
+import Foreign.C.Error (throwErrno)
+import Foreign.C.Types
+import Foreign.Marshal (alloca)
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (poke, sizeOf)
+import System.Posix.Files.ByteString
+import System.Posix.IO.Sendfile.Types
+import System.Posix.Types
+
+
+#include <sys/sendfile.h>
+#include <sys/socket.h>
+
+isLargeOffset :: Bool
+isLargeOffset = sizeOf (0 :: COff) == 8
+
+isLargeSize :: Bool
+isLargeSize = sizeOf (0 :: CSize) == 8
+
+safeSize :: CSize
+safeSize
+  | isLargeSize = 2^(60 :: Int)
+  | otherwise   = 2^(30 :: Int)
+
+
+
+-- |
+-- Simple binding for sendfile() of Linux.
+-- Used system calls:
+--
+--  - EntireFile -- stat() and sendfile()
+--
+--  - PartOfFile -- sendfile()
+--
+-- If the size of the file is unknown when sending the entire file,
+-- specifying PartOfFile is much faster.
+sendfileFd :: Fd -> Fd -> FileRange -> IO ()
+sendfileFd dst fd range =
+    alloca $ \offp -> case range of
+        EntireFile -> do
+            poke offp 0
+            -- System call is very slow. Use PartOfFile instead.
+            len <- fileSize <$> getFdStatus fd
+            let len' = fromIntegral len
+            sendfileloop dst fd offp len'
+        PartOfFile off len -> do
+            poke offp (fromIntegral off)
+            let len' = fromIntegral len
+            sendfileloop dst fd offp len'
+
+
+sendfileloop :: Fd -> Fd -> Ptr COff -> CSize -> IO ()
+sendfileloop dst src offp len = do
+    -- Multicore IO manager use edge-trigger mode.
+    -- So, calling threadWaitWrite only when errnor is eAGAIN.
+    let toSend
+          | len > safeSize = safeSize
+          | otherwise      = len
+    bytes <- c_sendfile dst src offp toSend
+    case bytes of
+        -1 -> throwErrno "System.Posix.IO.Sendfile.Internal"
+        0  -> return () -- the file is truncated
+        _  -> do
+            let left = len - fromIntegral bytes
+            when (left /= 0) $ sendfileloop dst src offp left
+
+
+-- Dst Src in order. take care
+foreign import ccall unsafe "sendfile"
+    c_sendfile32 :: Fd -> Fd -> Ptr COff -> CSize -> IO CSsize
+
+foreign import ccall unsafe "sendfile64"
+    c_sendfile64 :: Fd -> Fd -> Ptr COff -> CSize -> IO CSsize
+
+c_sendfile :: Fd -> Fd -> Ptr COff -> CSize -> IO CSsize
+c_sendfile
+  | isLargeOffset = c_sendfile64
+  | otherwise     = c_sendfile32

--- a/System/Posix/IO/Sendfile/Types.hs
+++ b/System/Posix/IO/Sendfile/Types.hs
@@ -1,0 +1,10 @@
+module System.Posix.IO.Sendfile.Types where
+
+-- |
+--  File range for 'sendfile'.
+
+data FileRange = EntireFile
+               | PartOfFile {
+                   rangeOffset :: Integer
+                 , rangeLength :: Integer
+                 }

--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -39,7 +39,11 @@ Library
     else
       if os(linux)
         CPP-Options:    -DOS_Linux
+        Exposed-Modules: System.Posix.IO.Sendfile
+                         System.Posix.IO.Sendfile.ByteString
+                         System.Posix.IO.Sendfile.Types
         Other-Modules:  Network.Sendfile.Linux
+                        System.Posix.IO.Sendfile.Internal
         Build-Depends:  unix
       else
         Other-Modules:  Network.Sendfile.Fallback
@@ -67,6 +71,9 @@ Test-Suite spec
                       , process
                       , simple-sendfile
                       , unix
+  if os(linux)
+      Other-Modules:  PosixSendfileSpec
+
 
 Source-Repository head
   Type:                 git

--- a/test/PosixSendfileSpec.hs
+++ b/test/PosixSendfileSpec.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module PosixSendfileSpec where
+
+import Control.Exception
+import Control.Monad
+import Control.Monad.Trans.Resource (MonadResource, runResourceT)
+import Data.ByteString.Char8 as BS
+import Data.Conduit
+import Data.Conduit.Binary as CB
+import System.Directory
+import System.Exit
+import System.IO
+import System.Posix.Files
+import System.Posix.IO
+import System.Posix.IO.Sendfile
+import System.Posix.IO.Sendfile.Types
+import System.Process
+import Test.Hspec
+
+----------------------------------------------------------------
+
+spec :: Spec
+spec =
+    describe "sendfile" $ do
+        it "sends an entire file" $
+            sendFile EntireFile `shouldReturn` ExitSuccess
+        it "sends a part of file" $
+            sendFile (PartOfFile 2000 1000000) `shouldReturn` ExitSuccess
+
+----------------------------------------------------------------
+
+sendFile :: FileRange -> IO ExitCode
+sendFile range = sendFileCore range
+
+
+sendFileCore :: FileRange -> IO ExitCode
+sendFileCore range = bracket setup teardown $ \(_, _) -> do
+    runResourceT $ copyfile range
+    system $ "cmp -s " ++ outputFile ++ " " ++ expectedFile
+    where
+    copyfile EntireFile =
+        -- of course, we can use <> here
+        sourceFile inputFile $$ sinkAppendFile expectedFile
+    copyfile (PartOfFile off len) =
+        sourceFile inputFile $= CB.isolate (off' + len')
+                             $$ (CB.take off' >> sinkAppendFile
+                                                 expectedFile)
+      where
+        off' = fromIntegral off
+        len' = fromIntegral len
+    setup = do
+        fd1 <- openFd inputFile ReadOnly Nothing defaultFileFlags
+        fd2 <- openFd outputFile WriteOnly (Just stdFileMode)
+                                 defaultFileFlags
+        sendfileFd fd2 fd1 range
+        return (fd1, fd2)
+    teardown (fd1, fd2) = do
+      closeFd fd1
+      closeFd fd2
+      removeFileIfExists outputFile
+      removeFileIfExists expectedFile
+    inputFile    = "test/inputFile"
+    outputFile   = "test/outputFile"
+    expectedFile = "test/expectedFile"
+
+
+----------------------------------------------------------------
+
+removeFileIfExists :: FilePath -> IO ()
+removeFileIfExists file = do
+    exist <- doesFileExist file
+    when exist $ removeFile file
+
+sinkAppendFile :: MonadResource m
+                  => FilePath
+                  -> Sink ByteString m ()
+sinkAppendFile fp = sinkIOHandle (openBinaryFile fp AppendMode)


### PR DESCRIPTION
This also provides a ByteString based module.

Fixes #19
Fixes #20 

The tests are a bit thin, but I didn't understand all of them, so I just implemented testing full and partial copy, which succeeds here.

Nonblocking is always _off_ for this posix mode since we expect it to be used on regular files.