### PR TITLE
simple-sendfile.cabal: include test file into source tarball

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -12,6 +12,8 @@ Category:               Network
 Cabal-Version:          >= 1.10
 Build-Type:             Simple
 
+Extra-source-files:     test/inputFile
+
 Flag allow-bsd
   Description:          Allow use of BSD sendfile (disable on GNU/kFreeBSD)
   Default:              True


### PR DESCRIPTION
Fixes bundled test failure:

  Running 1 test suites...
  Test suite spec: RUNNING...

  Sendfile
    sendfile
  spec: test/inputFile: openFd: does not exist (No such file or directory)
      sends an entire file FAILED [1]

Signed-off-by: Sergei Trofimovich <siarheit@google.com>