### PR TITLE
loosen version constraint for transformer

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -48,7 +48,7 @@ Library
         Other-Modules:  Network.Sendfile.Fallback
         Build-Depends:  conduit         >= 1.0 && < 1.3
                       , conduit-extra   >= 1.0 && < 1.2
-                      , transformers    >= 0.2.2 && < 0.5
+                      , transformers    >= 0.2.2 && < 0.6
                       , resourcet
 
 Test-Suite spec


### PR DESCRIPTION
right now some packages fail to build (on windows) bc simple-sendfile is not compatitble with the latest transformers library. 

https://github.com/sleexyz/hylogen/issues/55