### PR TITLE
Allow conduit-extra 1.2

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -47,7 +47,7 @@ Library
       else
         Other-Modules:  Network.Sendfile.Fallback
         Build-Depends:  conduit         >= 1.0 && < 1.3
-                      , conduit-extra   >= 1.0 && < 1.2
+                      , conduit-extra   >= 1.0 && < 1.3
                       , transformers    >= 0.2.2 && < 0.6
                       , resourcet
 


### PR DESCRIPTION
Tested locally and I can confirm that this builds without problem. Would it be possible to get a fix for this onto Hackage ASAP? It's affecting Stackage Nightly on Windows https://github.com/fpco/stackage/issues/3092