### PR TITLE
Adjust lower bounds on base to prevent building with GHC 7.8

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -23,7 +23,7 @@ Library
   GHC-Options:          -Wall
   Exposed-Modules:      Network.Sendfile
   Other-Modules:        Network.Sendfile.Types
-  Build-Depends:        base >= 4 && < 5
+  Build-Depends:        base >= 4.8 && < 5
                       , network
                       , bytestring
   -- NetBSD and OpenBSD don't have sendfile


### PR DESCRIPTION
`simple-sendfile-0.2.29` fails to build with GHC 7.8 and earlier, as shown in [this Travis build](https://travis-ci.org/scotty-web/scotty/jobs/593891064#L602). However, the version bounds in `simple-sendfile.cabal` do not reflect this. This patch bumps the lower version bounds on `base` so that it cannot be built on GHC 7.8 or earlier.