### PR TITLE
add undefined Fd* functions

### DIFF
--- a/Network/Sendfile.hs
+++ b/Network/Sendfile.hs
@@ -9,10 +9,8 @@
 module Network.Sendfile (
     sendfile
   , sendfileWithHeader
-#if OS_BSD || OS_MacOS || OS_Linux
   , sendfileFd
   , sendfileFdWithHeader
-#endif
   , FileRange(..)
   ) where
 

--- a/Network/Sendfile/Fallback.hs
+++ b/Network/Sendfile/Fallback.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE CPP #-}
 module Network.Sendfile.Fallback (
     sendfile
-  , sendfileWithHeader
-  ) where
+    , sendfileFd
+    , sendfileWithHeader
+    , sendfileFdWithHeader
+    ) where
 
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Data.ByteString (ByteString)
@@ -13,6 +15,7 @@ import Network.Socket
 import Network.Socket.ByteString
 import qualified Network.Socket.ByteString as SB
 import Control.Monad.Trans.Resource (runResourceT)
+import System.Posix.Types
 
 -- |
 -- Sendfile emulation using conduit.
@@ -25,6 +28,9 @@ sendfile sock path EntireFile hook =
     runResourceT $ sourceFile path $$ sinkSocket sock hook
 sendfile sock path (PartOfFile off len) hook =
     runResourceT $ EB.sourceFileRange path (Just off) (Just len) $$ sinkSocket sock hook
+
+sendfileFd :: Socket -> Fd -> FileRange -> IO () -> IO ()
+sendfileFd _sock _fd _range _hook = undefined
 
 -- See sinkHandle.
 sinkSocket :: MonadIO m => Socket -> IO () -> Sink ByteString m ()
@@ -45,6 +51,9 @@ sinkSocket s hook = NeedInput push close
 -- Used system calls:
 --
 --  - Used system calls: open(), stat(), read(), writev(), send() and close().
+
+sendfileFdWithHeader :: Socket -> Fd -> FileRange -> IO () -> [ByteString] -> IO ()
+sendfileFdWithHeader _sock _fd _range _hook _hdr = undefined
 
 sendfileWithHeader :: Socket -> FilePath -> FileRange -> IO () -> [ByteString] -> IO ()
 sendfileWithHeader sock path range hook hdr = do

--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -39,7 +39,7 @@ Library
                         Network.Sendfile.IOVec
       Build-Depends:    unix
     else
-      if os(linux)
+      if os(linux) && !impl(ghcjs)
         CPP-Options:    -DOS_Linux
         Exposed-Modules: System.Linux.Sendfile
         Other-Modules:  Network.Sendfile.Linux


### PR DESCRIPTION
This is arguably a pretty bad PR. All it does is add the `sendfileFd` and `sendfileFdWithHeader` functions as `undefined`. This allows us to build `warp` with `ghcjs` even though it would horribly fail when any sendfile functionarily was used.