### PR TITLE
Minor typo fix 'bofore'→'before'

### DIFF
--- a/Network/Sendfile/BSD.hsc
+++ b/Network/Sendfile/BSD.hsc
@@ -42,7 +42,7 @@ entire = 0
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfile :: Socket -> FilePath -> FileRange -> IO () -> IO ()
 sendfile sock path range hook = bracket setup teardown $ \fd ->
@@ -59,7 +59,7 @@ sendfile sock path range hook = bracket setup teardown $ \fd ->
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfileFd :: Socket -> Fd -> FileRange -> IO () -> IO ()
 sendfileFd sock fd range hook = do
@@ -109,7 +109,7 @@ sendloop dst src off len sentp hook = do
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfileWithHeader :: Socket -> FilePath -> FileRange -> IO () -> [ByteString] -> IO ()
 sendfileWithHeader sock path range hook hdr =
@@ -131,7 +131,7 @@ sendfileWithHeader sock path range hook hdr =
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfileFdWithHeader :: Socket -> Fd -> FileRange -> IO () -> [ByteString] -> IO ()
 sendfileFdWithHeader sock fd range hook hdr = do

--- a/Network/Sendfile/Linux.hsc
+++ b/Network/Sendfile/Linux.hsc
@@ -61,7 +61,7 @@ safeSize
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfile :: Socket -> FilePath -> FileRange -> IO () -> IO ()
 sendfile sock path range hook = bracket setup teardown $ \fd ->
@@ -91,7 +91,7 @@ sendfile' dst path range hook = bracket setup teardown $ \src ->
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 sendfileFd :: Socket -> Fd -> FileRange -> IO () -> IO ()
 sendfileFd sock fd range hook = do
 #if MIN_VERSION_network(3,1,0)
@@ -172,7 +172,7 @@ c_sendfile
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfileWithHeader :: Socket -> FilePath -> FileRange -> IO () -> [ByteString] -> IO ()
 sendfileWithHeader sock path range hook hdr = do
@@ -198,7 +198,7 @@ sendfileWithHeader sock path range hook hdr = do
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfileFdWithHeader :: Socket -> Fd -> FileRange -> IO () -> [ByteString] -> IO ()
 sendfileFdWithHeader sock fd range hook hdr = do

--- a/System/Linux/Sendfile.hs
+++ b/System/Linux/Sendfile.hs
@@ -23,7 +23,7 @@ import System.Posix.Types (Fd)
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfile :: Fd -> ByteString -> FileRange -> IO () -> IO ()
 sendfile = sendfile'
@@ -42,7 +42,7 @@ sendfile = sendfile'
 -- The fourth action argument is called when a file is sent as chunks.
 -- Chucking is inevitable if the socket is non-blocking (this is the
 -- default) and the file is large. The action is called after a chunk
--- is sent and bofore waiting the socket to be ready for writing.
+-- is sent and before waiting the socket to be ready for writing.
 
 sendfileFd :: Fd -> Fd -> FileRange -> IO () -> IO ()
 sendfileFd = sendfileFd'


### PR DESCRIPTION
Was reading the haddock documentation and saw this very small typo.