### PR TITLE
Allow building with `transformers-0.6.*` (GHC 9.6)

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -48,7 +48,7 @@ Library
         Other-Modules:  Network.Sendfile.Fallback
         Build-Depends:  conduit         >= 1.0 && < 1.4
                       , conduit-extra   >= 1.0 && < 1.4
-                      , transformers    >= 0.2.2 && < 0.6
+                      , transformers    >= 0.2.2 && < 0.7
                       , resourcet
 
 Test-Suite spec


### PR DESCRIPTION
GHC 9.6 bundles `transformers-0.6.1.0`. `simple-sendfile` can be made to build with it by simply raising the upper version bounds.