### PR TITLE
Use https for git repository

### DIFF
--- a/simple-sendfile.cabal
+++ b/simple-sendfile.cabal
@@ -17,7 +17,7 @@ extra-source-files: test/inputFile
 
 source-repository head
     type:     git
-    location: git://github.com/kazu-yamamoto/simple-sendfile
+    location: https://github.com/kazu-yamamoto/simple-sendfile
 
 flag allow-bsd
     description: Allow use of BSD sendfile (disable on GNU/kFreeBSD)


### PR DESCRIPTION
`git://` is no longer supported by GitHub.